### PR TITLE
serve form on get. parse it on post

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,15 +7,22 @@ import (
 )
 
 func formHandler(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		fmt.Fprintf(w, "ParseForm() err: %v", err)
-		return
+	switch r.Method {
+	case "GET":
+		 http.ServeFile(w, r, "./static/form.html")
+	case "POST":
+
+		// Call ParseForm() to parse the raw query and update r.PostForm and r.Form.
+		if err := r.ParseForm(); err != nil {
+			fmt.Fprintf(w, "ParseForm() err: %v", err)
+			return
+		}
+		fmt.Fprintf(w, "POST request successful")
+		name := r.FormValue("name")
+		address := r.FormValue("address")
+		fmt.Fprintf(w, "Name = %s\n", name)
+		fmt.Fprintf(w, "Address = %s\n", address)
 	}
-	fmt.Fprintf(w, "POST request successful")
-	name := r.FormValue("name")
-	address := r.FormValue("address")
-	fmt.Fprintf(w, "Name = %s\n", name)
-	fmt.Fprintf(w, "Address = %s\n", address)
 }
 
 func helloHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
I'm not sure if it's due to different versions of the go runtime or something else but I could not get the form to display when making requests to `localhost:8080/form`. Did some googling and found an example that worked and incorporated it into my fork.